### PR TITLE
feat: Use UNLOGGED tables for staging in delta loads

### DIFF
--- a/src/py_load_chembl/pipeline.py
+++ b/src/py_load_chembl/pipeline.py
@@ -183,6 +183,7 @@ class LoaderPipeline:
                 table_name="all",
                 data_source=self.pg_dump_path,
                 schema=staging_schema,
+                options={"unlogged_staging": True},
             )
             logger.info("Staging load complete.")
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -7,11 +7,13 @@ from py_load_chembl import api
 
 class TestApi(unittest.TestCase):
     @patch("py_load_chembl.api.LoaderPipeline")
-    @patch("py_load_chembl.api.PostgresAdapter")
-    def test_full_load_api_call(self, mock_adapter, mock_pipeline):
+    @patch("py_load_chembl.api.get_adapter")
+    def test_full_load_api_call(self, mock_get_adapter, mock_pipeline):
         """Tests that the full_load API function initializes and runs the pipeline correctly."""
         mock_pipeline_instance = MagicMock()
         mock_pipeline.return_value = mock_pipeline_instance
+        mock_adapter_instance = MagicMock()
+        mock_get_adapter.return_value = mock_adapter_instance
 
         api.full_load(
             connection_string="postgresql://user:pass@host/db",
@@ -20,12 +22,12 @@ class TestApi(unittest.TestCase):
             include_tables=["table1", "table2"],
         )
 
-        mock_adapter.assert_called_once_with(
-            connection_string="postgresql://user:pass@host/db"
+        mock_get_adapter.assert_called_once_with(
+            "postgresql://user:pass@host/db"
         )
 
         mock_pipeline.assert_called_once_with(
-            adapter=mock_adapter.return_value,
+            adapter=mock_adapter_instance,
             version="99",
             mode="FULL",
             output_dir=Path("/tmp/test"),
@@ -35,11 +37,13 @@ class TestApi(unittest.TestCase):
         mock_pipeline_instance.run.assert_called_once()
 
     @patch("py_load_chembl.api.LoaderPipeline")
-    @patch("py_load_chembl.api.PostgresAdapter")
-    def test_delta_load_api_call(self, mock_adapter, mock_pipeline):
+    @patch("py_load_chembl.api.get_adapter")
+    def test_delta_load_api_call(self, mock_get_adapter, mock_pipeline):
         """Tests that the delta_load API function initializes and runs the pipeline correctly."""
         mock_pipeline_instance = MagicMock()
         mock_pipeline.return_value = mock_pipeline_instance
+        mock_adapter_instance = MagicMock()
+        mock_get_adapter.return_value = mock_adapter_instance
 
         api.delta_load(
             connection_string="postgresql://user:pass@host/db",
@@ -48,12 +52,12 @@ class TestApi(unittest.TestCase):
             include_tables=["table3"],
         )
 
-        mock_adapter.assert_called_once_with(
-            connection_string="postgresql://user:pass@host/db"
+        mock_get_adapter.assert_called_once_with(
+            "postgresql://user:pass@host/db"
         )
 
         mock_pipeline.assert_called_once_with(
-            adapter=mock_adapter.return_value,
+            adapter=mock_adapter_instance,
             version="100",
             mode="DELTA",
             output_dir=Path("/tmp/delta"),


### PR DESCRIPTION
This commit implements a performance optimization for PostgreSQL delta loads as specified in the Functional Requirements Document (FRD), section 4.2.1.

During a delta load, the staging tables are now created as `UNLOGGED`. This reduces WAL (Write-Ahead Log) overhead, which can significantly improve performance for the initial data load into the staging schema.

The implementation modifies the `PostgresAdapter` to replace "CREATE TABLE" with "CREATE UNLOGGED TABLE" in the ChEMBL SQL dump before it is executed by `psql`. This change is only active during `DELTA` loads.

Additionally, this commit includes several fixes to the test suite that were necessary to verify the changes:
- Corrected the patch target in `tests/test_api.py` from the non-existent `api.PostgresAdapter` to `api.get_adapter`.
- Improved the robustness of an integration test (`test_full_load_standard_representation_mocked`) to prevent test pollution from other tests that use monkey-patching.