### PR TITLE
Make package PEP compliant and PyPI ready

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,24 @@ description = "A Python package for loading the ChEMBL database into various rel
 authors = ["Gowtham Rao rao@ohdsi.org"]
 license = "Apache-2.0"
 readme = "README.md"
+homepage = "https://github.com/ohdsi/py-load-chembl"
+repository = "https://github.com/ohdsi/py-load-chembl"
+documentation = "https://github.com/ohdsi/py-load-chembl"
+keywords = ["chembl", "database", "etl", "bioinformatics", "cheminformatics", "postgres", "postgresql", "data-engineering"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: Apache Software License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Topic :: Database",
+    "Topic :: Scientific/Engineering :: Bio-Informatics",
+    "Topic :: Scientific/Engineering :: Chemistry",
+]
 
 [tool.poetry.dependencies]
 python = "^3.9"

--- a/src/py_load_chembl/adapters/factory.py
+++ b/src/py_load_chembl/adapters/factory.py
@@ -2,6 +2,7 @@ from urllib.parse import urlparse
 from py_load_chembl.adapters.base import DatabaseAdapter
 from py_load_chembl.adapters.postgres import PostgresAdapter
 
+
 def get_adapter(connection_string: str) -> DatabaseAdapter:
     """
     Factory function that returns the appropriate database adapter based on the

--- a/src/py_load_chembl/adapters/postgres.py
+++ b/src/py_load_chembl/adapters/postgres.py
@@ -379,7 +379,9 @@ class PostgresAdapter(DatabaseAdapter):
         Creates a new table in the target schema with the same schema as the source table
         using PostgreSQL's 'LIKE' syntax.
         """
-        logger.info(f"Creating table '{target_schema}.{table_name}' like '{source_schema}.{table_name}'...")
+        logger.info(
+            f"Creating table '{target_schema}.{table_name}' like '{source_schema}.{table_name}'..."
+        )
         sql = f'CREATE TABLE "{target_schema}"."{table_name}" (LIKE "{source_schema}"."{table_name}" INCLUDING ALL);'
         self.execute_sql(sql)
         logger.info(f"Table '{target_schema}.{table_name}' created successfully.")
@@ -447,7 +449,9 @@ class PostgresAdapter(DatabaseAdapter):
             if unlogged:
                 # Use simple string replacement. It's fast and the ChEMBL DDL is consistent.
                 # A regex would be overkill and potentially slower.
-                sql_content = sql_content.replace("CREATE TABLE", "CREATE UNLOGGED TABLE")
+                sql_content = sql_content.replace(
+                    "CREATE TABLE", "CREATE UNLOGGED TABLE"
+                )
 
             full_script = f'SET search_path = "{schema}", public;\n{sql_content}'
 

--- a/src/py_load_chembl/config.py
+++ b/src/py_load_chembl/config.py
@@ -5,8 +5,10 @@ Configuration for py_load_chembl, including predefined lists of tables.
 """
 import enum
 
+
 class Representation(str, enum.Enum):
     """Enum for the different data representations that can be loaded."""
+
     FULL = "full"
     STANDARD = "standard"
 
@@ -16,33 +18,33 @@ class Representation(str, enum.Enum):
 # Structure-Activity Relationship (SAR) analysis use cases.
 # It includes the core entities (molecules, targets, assays, activities)
 # and their essential supporting lookup tables.
-STANDARD_TABLE_SUBSET = sorted([
-    # Core Data Tables
-    "activities",
-    "assays",
-    "molecule_dictionary",
-    "compound_structures",
-    "target_dictionary",
-
-    # Essential Supporting Tables
-    "chembl_id_lookup",
-    "compound_properties",
-    "source",
-    "target_type",
-    "organism_class",
-
-    # Foreign key dependencies for the above tables to ensure integrity
-    "activity_stds_lookup",
-    "assay_type",
-    "component_sequences",
-    "confidence_score_lookup",
-    "compound_records",
-    "data_validity_lookup",
-    "docs",
-    "relationship_type",
-    "research_stem",
-    "site_components",
-    "cell_dictionary",
-    "protein_family_classification",
-    "protein_classification",
-])
+STANDARD_TABLE_SUBSET = sorted(
+    [
+        # Core Data Tables
+        "activities",
+        "assays",
+        "molecule_dictionary",
+        "compound_structures",
+        "target_dictionary",
+        # Essential Supporting Tables
+        "chembl_id_lookup",
+        "compound_properties",
+        "source",
+        "target_type",
+        "organism_class",
+        # Foreign key dependencies for the above tables to ensure integrity
+        "activity_stds_lookup",
+        "assay_type",
+        "component_sequences",
+        "confidence_score_lookup",
+        "compound_records",
+        "data_validity_lookup",
+        "docs",
+        "relationship_type",
+        "research_stem",
+        "site_components",
+        "cell_dictionary",
+        "protein_family_classification",
+        "protein_classification",
+    ]
+)

--- a/src/py_load_chembl/downloader.py
+++ b/src/py_load_chembl/downloader.py
@@ -22,9 +22,7 @@ class ChecksumError(ValueError):
     """Custom exception for checksum validation errors."""
 
 
-def download_chembl_db(
-    version: int, output_dir: Path, plain_sql: bool = False
-) -> Path:
+def download_chembl_db(version: int, output_dir: Path, plain_sql: bool = False) -> Path:
     """
     Downloads the ChEMBL database dump for a specific version and verifies its integrity.
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -22,9 +22,7 @@ class TestApi(unittest.TestCase):
             include_tables=["table1", "table2"],
         )
 
-        mock_get_adapter.assert_called_once_with(
-            "postgresql://user:pass@host/db"
-        )
+        mock_get_adapter.assert_called_once_with("postgresql://user:pass@host/db")
 
         mock_pipeline.assert_called_once_with(
             adapter=mock_adapter_instance,
@@ -52,9 +50,7 @@ class TestApi(unittest.TestCase):
             include_tables=["table3"],
         )
 
-        mock_get_adapter.assert_called_once_with(
-            "postgresql://user:pass@host/db"
-        )
+        mock_get_adapter.assert_called_once_with("postgresql://user:pass@host/db")
 
         mock_pipeline.assert_called_once_with(
             adapter=mock_adapter_instance,

--- a/tests/test_integration_postgres.py
+++ b/tests/test_integration_postgres.py
@@ -3,8 +3,6 @@ import psycopg2
 import gzip
 import hashlib
 import tarfile
-from pathlib import Path
-import io
 import json
 import logging
 from unittest.mock import patch
@@ -306,7 +304,9 @@ def test_postgres_delta_load_workflow(
             )
             insert_count, update_count = cursor.fetchone()
             assert insert_count == 0, "No new records should be inserted"
-            assert update_count == 2, "Both existing records should be updated by the merge"
+            assert (
+                update_count == 2
+            ), "Both existing records should be updated by the merge"
     finally:
         conn.close()
 
@@ -566,7 +566,6 @@ def test_full_load_standard_representation(
         dir_info.type = tarfile.DIRTYPE
         tar.addfile(dir_info)
     tar_gz_content = tar_gz_path.read_bytes()
-
 
     tar_gz_url = f"https://ftp.ebi.ac.uk/pub/databases/chembl/ChEMBLdb/releases/chembl_{chembl_version}/{tar_gz_filename}"
     checksum_url = f"https://ftp.ebi.ac.uk/pub/databases/chembl/ChEMBLdb/releases/chembl_{chembl_version}/checksums.txt"

--- a/tests/unit/test_adapter_factory.py
+++ b/tests/unit/test_adapter_factory.py
@@ -2,6 +2,7 @@ import pytest
 from py_load_chembl.adapters.factory import get_adapter
 from py_load_chembl.adapters.postgres import PostgresAdapter
 
+
 def test_get_adapter_returns_postgres_adapter():
     """
     Tests that the factory returns a PostgresAdapter for a postgresql connection string.
@@ -9,16 +10,22 @@ def test_get_adapter_returns_postgres_adapter():
     adapter = get_adapter("postgresql://user:pass@host/db")
     assert isinstance(adapter, PostgresAdapter)
 
+
 def test_get_adapter_raises_for_unsupported_scheme():
     """
     Tests that the factory raises a NotImplementedError for an unsupported scheme.
     """
-    with pytest.raises(NotImplementedError, match="Database scheme 'mysql' is not supported."):
+    with pytest.raises(
+        NotImplementedError, match="Database scheme 'mysql' is not supported."
+    ):
         get_adapter("mysql://user:pass@host/db")
+
 
 def test_get_adapter_raises_for_invalid_string():
     """
     Tests that the factory raises an error for a malformed connection string.
     """
-    with pytest.raises(NotImplementedError, match="Database scheme '' is not supported."):
+    with pytest.raises(
+        NotImplementedError, match="Database scheme '' is not supported."
+    ):
         get_adapter("not_a_real_connection_string")

--- a/tests/unit/test_downloader.py
+++ b/tests/unit/test_downloader.py
@@ -79,9 +79,7 @@ def test_download_and_verify_checksum_error(mock_downloader):
     output_dir = mock_params["output_dir"]
     file_path = output_dir / mock_params["file_name"]
 
-    with pytest.raises(
-        ChecksumError, match="is invalid. The file has been deleted."
-    ):
+    with pytest.raises(ChecksumError, match="is invalid. The file has been deleted."):
         downloader.download_chembl_db(
             version=mock_params["version"],
             output_dir=output_dir,


### PR DESCRIPTION
This commit addresses two main goals:
1.  Makes the package compliant with PEP conventions by running `black` for code formatting and `ruff` for linting.
2.  Prepares the package for PyPI submission by enhancing the `pyproject.toml` file with necessary metadata.

Key changes:
- Added `homepage`, `repository`, `keywords`, and `classifiers` to `pyproject.toml` to improve discoverability and provide more context on PyPI.
- Ran `black` to format the codebase, ensuring consistent style.
- Ran `ruff --fix` to automatically correct linting errors, such as unused imports.