### PR TITLE
Fix ruff linting errors in tests (#39)

### DIFF
--- a/tests/test_adapter_unit.py
+++ b/tests/test_adapter_unit.py
@@ -2,6 +2,8 @@ import unittest
 from unittest.mock import patch, MagicMock
 from pathlib import Path
 import pytest
+import tarfile
+import gzip
 
 from py_load_chembl.adapters.postgres import PostgresAdapter
 
@@ -117,9 +119,6 @@ class TestPostgresAdapterUnit(unittest.TestCase):
 @pytest.fixture
 def postgres_adapter():
     return PostgresAdapter("postgresql://user:password@host:5432/dbname")
-
-import tarfile
-import gzip
 
 @patch("shutil.which", return_value="/usr/bin/pg_restore")
 @patch("subprocess.run")

--- a/tests/unit/test_cli_unit.py
+++ b/tests/unit/test_cli_unit.py
@@ -1,5 +1,4 @@
-import pytest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 from typer.testing import CliRunner
 from py_load_chembl.cli import app
 from py_load_chembl import downloader


### PR DESCRIPTION
This commit fixes the following `ruff` linting errors:
- E402: Module level import not at top of file in `tests/test_adapter_unit.py`
- F401: `pytest` imported but unused in `tests/unit/test_cli_unit.py`
- F401: `unittest.mock.MagicMock` imported but unused in `tests/unit/test_cli_unit.py`

The unused imports were removed automatically using `ruff check . --fix`. The misplaced imports in `tests/test_adapter_unit.py` were moved to the top of the file.