### PR TITLE
Fix: Use 'docker compose' in GitHub Actions workflow (#41)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         $HOME/.local/bin/poetry run mypy .
 
     - name: Start services
-      run: docker-compose -f tests/docker-compose.yml up -d
+      run: docker compose -f tests/docker-compose.yml up -d
 
     - name: Run tests
       run: |


### PR DESCRIPTION
The 'docker-compose' command is deprecated and not available in newer GitHub Actions runners. This commit updates the workflow to use the 'docker compose' command, which is the current standard.